### PR TITLE
test: make sandbox test run sequentially

### DIFF
--- a/packages/sandbox/jest.config.ts
+++ b/packages/sandbox/jest.config.ts
@@ -13,4 +13,6 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/sandbox',
+  maxConcurrency: 1,
+  maxWorkers: 1,
 };


### PR DESCRIPTION
## TL;DR; 

This MR stabilizes the e2e test by making them run sequentially

## Description

We are currently having issues with the e2e test located in the sandbox. 

The issue is cause by running test in parallel. Creating and destroy file that may be required for other test.

While we chose a proper testing strategy we can stabilize the test by simply turning off all concurrency.

This will unblock us for the migration and allow for an easer transition to a new e2e and integration testing strategy.